### PR TITLE
pc: static_prt disabled by default.

### DIFF
--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -2467,7 +2467,7 @@ static void pc_machine_initfn(Object *obj)
     pcms->smbus = true;
     pcms->sata = true;
     pcms->pit = true;
-    pcms->static_prt = true;
+    pcms->static_prt = false;
     pcms->fw = true;
 }
 


### PR DESCRIPTION
static_ptr has some conflicts with virtio-rng devices.

This can be disabled but if the flag to disable is
used with qemu verions that does not provide this flag,
qemu will fail.

Lets keep the original behavior, and enabled explicitly.

See: https://github.com/kata-containers/runtime/issues/445

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>